### PR TITLE
Fix import path in _examples

### DIFF
--- a/_examples/collision.go
+++ b/_examples/collision.go
@@ -1,6 +1,6 @@
 package main
 
-import tl "github.com/joelotter/termloop"
+import tl "github.com/JoelOtter/termloop"
 
 type CollRec struct {
 	r    *tl.Rectangle

--- a/_examples/movingtext.go
+++ b/_examples/movingtext.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	tl "github.com/joelotter/termloop"
+	tl "github.com/JoelOtter/termloop"
 	"os"
 )
 

--- a/_examples/pyramid.go
+++ b/_examples/pyramid.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	tl "github.com/joelotter/termloop"
+	tl "github.com/JoelOtter/termloop"
 	"math/rand"
 	"strconv"
 	"time"


### PR DESCRIPTION
This change is necessary in order to cope with case-sensitive.