### PR TITLE
Skip draw when nothing has changed

### DIFF
--- a/screen.go
+++ b/screen.go
@@ -6,14 +6,15 @@ import "github.com/nsf/termbox-go"
 // To draw on the screen, create Drawables and set their positions.
 // Then, add them to the Screen's Level, or to the Screen directly (e.g. a HUD).
 type Screen struct {
-	canvas   Canvas
-	level    Level
-	entities []Drawable
-	width    int
-	height   int
-	delta    float64
-	offsetx  int
-	offsety  int
+	oldCanvas Canvas
+	canvas    Canvas
+	level     Level
+	entities  []Drawable
+	width     int
+	height    int
+	delta     float64
+	offsetx   int
+	offsety   int
 }
 
 // NewScreen creates a new Screen, with no entities or level.
@@ -50,15 +51,19 @@ func (s *Screen) Draw() {
 	for _, e := range s.entities {
 		e.Draw(s)
 	}
-	// Draw to terminal
-	for i, col := range s.canvas {
-		for j, cell := range col {
-			termbox.SetCell(i, j, cell.Ch,
-				termbox.Attribute(cell.Fg),
-				termbox.Attribute(cell.Bg))
+	// Check if anything changed between Draws
+	if !s.canvas.equals(&s.oldCanvas) {
+		// Draw to terminal
+		for i, col := range s.canvas {
+			for j, cell := range col {
+				termbox.SetCell(i, j, cell.Ch,
+					termbox.Attribute(cell.Fg),
+					termbox.Attribute(cell.Bg))
+			}
 		}
+		termbox.Flush()
 	}
-	termbox.Flush()
+	s.oldCanvas = s.canvas
 }
 
 func (s *Screen) resize(w, h int) {

--- a/termloop.go
+++ b/termloop.go
@@ -20,6 +20,29 @@ func NewCanvas(width, height int) Canvas {
 	return canvas
 }
 
+func (canvas *Canvas) equals(oldCanvas *Canvas) bool {
+	c := *canvas
+	c2 := *oldCanvas
+	if c2 == nil {
+		return false
+	}
+	if len(c) != len(c2) {
+		return false
+	}
+	if len(c[0]) != len(c2[0]) {
+		return false
+	}
+	for i := range c {
+		for j := range c[i] {
+			equal := c[i][j].equals(&(c2[i][j]))
+			if !equal {
+				return false
+			}
+		}
+	}
+	return true
+}
+
 // CanvasFromString returns a new Canvas, built from
 // the characters in the string str. Newline characters in
 // the string are interpreted as a new Canvas row.
@@ -88,6 +111,12 @@ type Cell struct {
 	Fg Attr // Foreground colour
 	Bg Attr // Background color
 	Ch rune // The character to draw
+}
+
+func (c *Cell) equals(c2 *Cell) bool {
+	return c.Fg == c2.Fg &&
+		c.Bg == c2.Bg &&
+		c.Ch == c2.Ch
 }
 
 // Provides an event, for input, errors or resizing.


### PR DESCRIPTION
Since drawing to the canvas looks to be the bottleneck, this change keeps the last canvas to the `Screen` structure and checks if the canvas has changed between the draws.

This is rather crude approach but the performance could be is significant, depending on the usage:

from: 

```
(pprof) top10
55s of 57.30s total (95.99%)
Dropped 126 nodes (cum <= 0.29s)
Showing top 10 nodes out of 29 (cum >= 0.79s)
      flat  flat%   sum%        cum   cum%
    48.07s 83.89% 83.89%     48.07s 83.89%  github.com/mattn/go-runewidth.(*Condition).RuneWidth
     2.36s  4.12% 88.01%     51.24s 89.42%  github.com/nsf/termbox-go.Flush
     1.75s  3.05% 91.06%     55.38s 96.65%  github.com/JoelOtter/termloop.(*Screen).Draw
     0.74s  1.29% 92.36%     48.81s 85.18%  github.com/mattn/go-runewidth.RuneWidth
     0.61s  1.06% 93.42%      0.61s  1.06%  github.com/JoelOtter/termloop.(*Screen).RenderCell
     0.55s  0.96% 94.38%      0.55s  0.96%  github.com/JoelOtter/termloop.(*BaseLevel).DrawBackground
     0.45s  0.79% 95.17%      0.45s  0.79%  runtime.futex
     0.24s  0.42% 95.58%      0.75s  1.31%  github.com/JoelOtter/termloop.(*Rectangle).Draw
     0.13s  0.23% 95.81%      0.87s  1.52%  runtime.makeslice
     0.10s  0.17% 95.99%      0.79s  1.38%  runtime.newarray
```

to:

```
(pprof) top10
8090ms of 11500ms total (70.35%)
Dropped 87 nodes (cum <= 57.50ms)
Showing top 10 nodes out of 95 (cum >= 370ms)
      flat  flat%   sum%        cum   cum%
    1910ms 16.61% 16.61%     1910ms 16.61%  github.com/aquilax/termloop.(*Canvas).equals
    1480ms 12.87% 29.48%     1480ms 12.87%  github.com/mattn/go-runewidth.(*Condition).RuneWidth
    1460ms 12.70% 42.17%     1460ms 12.70%  github.com/aquilax/termloop.(*Screen).RenderCell
     860ms  7.48% 49.65%      860ms  7.48%  github.com/aquilax/termloop.(*BaseLevel).DrawBackground
     670ms  5.83% 55.48%     1730ms 15.04%  github.com/aquilax/termloop.(*Rectangle).Draw
     450ms  3.91% 59.39%      450ms  3.91%  runtime.futex
     410ms  3.57% 62.96%      410ms  3.57%  runtime.memclr
     380ms  3.30% 66.26%      450ms  3.91%  runtime.scanblock
     260ms  2.26% 68.52%     1310ms 11.39%  runtime.mallocgc
     210ms  1.83% 70.35%      370ms  3.22%  runtime.scanobject

```

NOTE: The running times are different so, better look at the percentages.

A better approach could be setting a `dirty` flag when something changes. That would eliminate the need of looping through the canvas.