### PR TITLE
Allow user to set FPS

### DIFF
--- a/_examples/collision.go
+++ b/_examples/collision.go
@@ -1,6 +1,6 @@
 package main
 
-import tl "github.com/JoelOtter/termloop"
+import tl "github.com/jodizzle/termloop"
 
 type CollRec struct {
 	r    *tl.Rectangle

--- a/_examples/collision.go
+++ b/_examples/collision.go
@@ -1,6 +1,6 @@
 package main
 
-import tl "github.com/jodizzle/termloop"
+import tl "github.com/JoelOtter/termloop"
 
 type CollRec struct {
 	r    *tl.Rectangle
@@ -45,7 +45,7 @@ func (r *CollRec) Collide(p tl.Physical) {
 
 func main() {
 	g := tl.NewGame()
-	g.Screen().SetFps(120)
+	g.Screen().SetFps(60)
 	l := tl.NewBaseLevel(tl.Cell{
 		Bg: tl.ColorWhite,
 	})

--- a/_examples/collision.go
+++ b/_examples/collision.go
@@ -45,6 +45,7 @@ func (r *CollRec) Collide(p tl.Physical) {
 
 func main() {
 	g := tl.NewGame()
+	g.Screen().SetFps(120)
 	l := tl.NewBaseLevel(tl.Cell{
 		Bg: tl.ColorWhite,
 	})

--- a/game.go
+++ b/game.go
@@ -103,6 +103,6 @@ mainloop:
 		g.screen.delta = update.Sub(clock).Seconds()
 		clock = update
 		g.screen.Draw()
-		time.Sleep(time.Duration(g.screen.delta + 1000.0/60.0)*time.Millisecond)
+		time.Sleep(time.Duration(g.screen.delta + 1000.0/g.screen.fps)*time.Millisecond)
 	}
 }

--- a/game.go
+++ b/game.go
@@ -105,6 +105,6 @@ mainloop:
 		}
 
 		g.screen.Draw()
-		time.Sleep(time.Duration((update.Sub(time.Now()).Seconds()*1000.0) + 1000.0/g.screen.fps)*time.Millisecond)
+		time.Sleep(time.Duration((update.Sub(time.Now()).Seconds()*1000.0)+1000.0/g.screen.fps) * time.Millisecond)
 	}
 }

--- a/game.go
+++ b/game.go
@@ -103,5 +103,6 @@ mainloop:
 		g.screen.delta = update.Sub(clock).Seconds()
 		clock = update
 		g.screen.Draw()
+		time.Sleep(time.Duration(g.screen.delta + 1000.0/60.0)*time.Millisecond)
 	}
 }

--- a/game.go
+++ b/game.go
@@ -105,6 +105,8 @@ mainloop:
 		}
 
 		g.screen.Draw()
+		// If g.screen.fps is zero (the default), then 1000.0/g.screen.fps -> +Inf -> time.Duration(+Inf), which
+		// is a negative number, and so time.Sleep returns immediately.
 		time.Sleep(time.Duration((update.Sub(time.Now()).Seconds()*1000.0)+1000.0/g.screen.fps) * time.Millisecond)
 	}
 }

--- a/game.go
+++ b/game.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/nsf/termbox-go"
 	"time"
+	//"strconv"
 )
 
 // Represents a top-level Termloop application.
@@ -86,6 +87,10 @@ func (g *Game) Start() {
 
 mainloop:
 	for {
+		update := time.Now()
+		g.screen.delta = update.Sub(clock).Seconds()
+		clock = update
+
 		select {
 		case ev := <-g.input.eventQ:
 			if ev.Key == g.input.endKey {
@@ -99,10 +104,9 @@ mainloop:
 		default:
 			g.screen.Tick(Event{Type: EventNone})
 		}
-		update := time.Now()
-		g.screen.delta = update.Sub(clock).Seconds()
-		clock = update
+
 		g.screen.Draw()
-		time.Sleep(time.Duration(g.screen.delta + 1000.0/g.screen.fps)*time.Millisecond)
+		//g.Log(strconv.FormatFloat(update.Sub(time.Now()).Seconds()*1000.0, 'f', 2, 32))
+		time.Sleep(time.Duration((update.Sub(time.Now()).Seconds()*1000.0) + 1000.0/g.screen.fps)*time.Millisecond)
 	}
 }

--- a/game.go
+++ b/game.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/nsf/termbox-go"
 	"time"
-	//"strconv"
 )
 
 // Represents a top-level Termloop application.
@@ -106,7 +105,6 @@ mainloop:
 		}
 
 		g.screen.Draw()
-		//g.Log(strconv.FormatFloat(update.Sub(time.Now()).Seconds()*1000.0, 'f', 2, 32))
 		time.Sleep(time.Duration((update.Sub(time.Now()).Seconds()*1000.0) + 1000.0/g.screen.fps)*time.Millisecond)
 	}
 }

--- a/screen.go
+++ b/screen.go
@@ -13,7 +13,7 @@ type Screen struct {
 	width     int
 	height    int
 	delta     float64
-	fps		  float64
+	fps       float64
 	offsetx   int
 	offsety   int
 }

--- a/screen.go
+++ b/screen.go
@@ -13,6 +13,7 @@ type Screen struct {
 	width     int
 	height    int
 	delta     float64
+	fps		  float64
 	offsetx   int
 	offsety   int
 }
@@ -114,6 +115,13 @@ func (s *Screen) RemoveEntity(d Drawable) {
 // frame was rendered. Can be used for timings and animation.
 func (s *Screen) TimeDelta() float64 {
 	return s.delta
+}
+
+// Set the screen framerate.  By default, termloop will draw the
+// the screen as fast as possible, which may use a lot of system
+// resources.
+func (s *Screen) SetFps(f float64) {
+	s.fps = f
 }
 
 // RenderCell updates the Cell at a given position on the Screen


### PR DESCRIPTION
As discussed on Gitter and in accordance with #18, these changes make it possible to set a relative cap on the frames per second of a screen.  For example, running 
```Go
g := termloop.NewGame()
g.Screen().SetFps(60)
```
would handle input and draw to the screen at a rate of no more than around 60 FPS.  This is done through a simple sleep command, as per http://gameprogrammingpatterns.com/game-loop.html#take-a-little-nap.  By default (or by running ```SetFps(0)```) no FPS is set.  I've also edited ```_examples/collision.go``` as a further example of ```screen.SetFps``` in action.

The main motivation for setting the FPS is to reduce the impact on system resources; running termloop with the mainloop executing as fast as possible can result in high CPU usage, for instance.  Establishing a reasonable limit can greatly improve performance without much or any impact on gameplay.

Since the current approach is fairly basic, there's still room for improvement.  Updating a game based on ```screen.TimeDelta()``` should still function properly, though the FpsText utility seems to be a bit buggy.  Also (and possibly related to the FpsText bugginess), a simple sleep doesn't prevent the game from running *slower* than the set FPS, but that's less critical to the use case as of right now.