### PR TITLE
Two small changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,16 +130,12 @@ func (player *Player) Tick(event tl.Event) {
 		switch event.Key { // If so, switch on the pressed key.
 		case tl.KeyArrowRight:
 			player.entity.SetPosition(x+1, y)
-			break
 		case tl.KeyArrowLeft:
 			player.entity.SetPosition(x-1, y)
-			break
 		case tl.KeyArrowUp:
 			player.entity.SetPosition(x, y-1)
-			break
 		case tl.KeyArrowDown:
 			player.entity.SetPosition(x, y+1)
-			break
 		}
 	}
 }
@@ -200,16 +196,12 @@ func (player *Player) Tick(event tl.Event) {
 		switch event.Key { // If so, switch on the pressed key.
 		case tl.KeyArrowRight:
 			player.entity.SetPosition(player.prevX+1, player.prevY)
-			break
 		case tl.KeyArrowLeft:
 			player.entity.SetPosition(player.prevX-1, player.prevY)
-			break
 		case tl.KeyArrowUp:
 			player.entity.SetPosition(player.prevX, player.prevY-1)
-			break
 		case tl.KeyArrowDown:
 			player.entity.SetPosition(player.prevX, player.prevY+1)
-			break
 		}
 	}
 }

--- a/_examples/audio.go
+++ b/_examples/audio.go
@@ -48,16 +48,12 @@ func (sc *SoundCtrl) Tick(ev tl.Event) {
 		switch ev.Key {
 		case tl.KeyArrowRight:
 			sc.track.Play()
-			break
 		case tl.KeyArrowLeft:
 			sc.track.Restart()
-			break
 		case tl.KeyArrowUp:
 			sc.track.Pause()
-			break
 		case tl.KeyArrowDown:
 			sc.track.Stop()
-			break
 		}
 	}
 }

--- a/_examples/collision.go
+++ b/_examples/collision.go
@@ -21,16 +21,12 @@ func (r *CollRec) Tick(ev tl.Event) {
 		switch ev.Key {
 		case tl.KeyArrowRight:
 			r.r.SetPosition(r.px+1, r.py)
-			break
 		case tl.KeyArrowLeft:
 			r.r.SetPosition(r.px-1, r.py)
-			break
 		case tl.KeyArrowUp:
 			r.r.SetPosition(r.px, r.py-1)
-			break
 		case tl.KeyArrowDown:
 			r.r.SetPosition(r.px, r.py+1)
-			break
 		}
 	}
 }

--- a/_examples/image.go
+++ b/_examples/image.go
@@ -27,16 +27,12 @@ func (i *Image) Tick(ev tl.Event) {
 		switch ev.Key {
 		case tl.KeyArrowRight:
 			x -= 1
-			break
 		case tl.KeyArrowLeft:
 			x += 1
-			break
 		case tl.KeyArrowUp:
 			y += 1
-			break
 		case tl.KeyArrowDown:
 			y -= 1
-			break
 		}
 		i.e.SetPosition(x, y)
 	}

--- a/_examples/levelmap.go
+++ b/_examples/levelmap.go
@@ -20,16 +20,12 @@ func (p *Player) Tick(ev tl.Event) {
 		switch ev.Key {
 		case tl.KeyArrowRight:
 			x += 1
-			break
 		case tl.KeyArrowLeft:
 			x -= 1
-			break
 		case tl.KeyArrowUp:
 			y -= 1
-			break
 		case tl.KeyArrowDown:
 			y += 1
-			break
 		}
 		p.e.SetPosition(x, y)
 	}

--- a/_examples/movingtext.go
+++ b/_examples/movingtext.go
@@ -21,16 +21,12 @@ func (m *MovingText) Tick(ev tl.Event) {
 		switch ev.Key {
 		case tl.KeyArrowRight:
 			x += 1
-			break
 		case tl.KeyArrowLeft:
 			x -= 1
-			break
 		case tl.KeyArrowUp:
 			y -= 1
-			break
 		case tl.KeyArrowDown:
 			y += 1
-			break
 		}
 		m.text.SetPosition(x, y)
 	}

--- a/_examples/pyramid.go
+++ b/_examples/pyramid.go
@@ -145,16 +145,12 @@ func (b *Block) Tick(ev tl.Event) {
 		switch ev.Key {
 		case tl.KeyArrowRight:
 			b.r.SetPosition(b.px+1, b.py)
-			break
 		case tl.KeyArrowLeft:
 			b.r.SetPosition(b.px-1, b.py)
-			break
 		case tl.KeyArrowUp:
 			b.r.SetPosition(b.px, b.py-1)
-			break
 		case tl.KeyArrowDown:
 			b.r.SetPosition(b.px, b.py+1)
-			break
 		}
 	}
 }

--- a/_examples/tutorial.go
+++ b/_examples/tutorial.go
@@ -22,16 +22,12 @@ func (player *Player) Tick(event tl.Event) {
 		switch event.Key { // If so, switch on the pressed key.
 		case tl.KeyArrowRight:
 			player.entity.SetPosition(player.prevX+1, player.prevY)
-			break
 		case tl.KeyArrowLeft:
 			player.entity.SetPosition(player.prevX-1, player.prevY)
-			break
 		case tl.KeyArrowUp:
 			player.entity.SetPosition(player.prevX, player.prevY-1)
-			break
 		case tl.KeyArrowDown:
 			player.entity.SetPosition(player.prevX, player.prevY+1)
-			break
 		}
 	}
 }

--- a/extra/audio.go
+++ b/extra/audio.go
@@ -8,7 +8,7 @@ package extra
 // installed on your system.
 
 import (
-	"code.google.com/p/portaudio-go/portaudio"
+	"github.com/gordonklaus/portaudio"
 	"github.com/mkb218/gosndfile/sndfile"
 )
 

--- a/map.go
+++ b/map.go
@@ -83,16 +83,13 @@ func LoadLevelFromMap(jsonMap string, parsers map[string]EntityParser, l Level) 
 		switch lm.Type {
 		case "Rectangle":
 			entity = parseRectangle(lm.Data)
-			break
 		case "Text":
 			entity = parseText(lm.Data)
-			break
 		case "Entity":
 			entity, err = parseEntity(lm.Data)
 			if err != nil {
 				return err
 			}
-			break
 		default:
 			entity = parsers[lm.Type](lm.Data)
 		}


### PR DESCRIPTION
1.  In the comments of #23 @leavengood picked up on the non-necessary `break` statements inside Go `switch` blocks.  I had noticed this a while back and went ahead and removed them from the repository (hopefully this isn't too presumptuous).
2.  The old link for the portaudio Go bindings package died with Google Code, and it now redirects to [a Github page](https://github.com/gordonklaus/portaudio), so the relevant import statement in `audio.go` needs to be changed.