### PR TITLE
Add Key constant values MouseRelease, MouseWheelUp, MouseWheelDown

### DIFF
--- a/_examples/click.go
+++ b/_examples/click.go
@@ -24,7 +24,7 @@ func (info *EventInfo) Tick(ev tl.Event) {
 	if ev.Type != tl.EventMouse {
 		return
 	}
-	name := "Unknown Event"
+	var name string
 	switch ev.Key {
 	case tl.MouseLeft:
 		name = "Mouse Left"
@@ -38,6 +38,8 @@ func (info *EventInfo) Tick(ev tl.Event) {
 		name = "Mouse Wheel Down"
 	case tl.MouseRelease:
 		name = "Mouse Release"
+	default:
+		name = fmt.Sprintf("Unknown Key (%#x)", ev.Key)
 	}
 	info.text.SetText(fmt.Sprintf("%s @ [%d, %d]", name, ev.MouseX, ev.MouseY))
 }

--- a/_examples/click.go
+++ b/_examples/click.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-
 	tl "github.com/JoelOtter/termloop"
 )
 
@@ -12,7 +11,7 @@ type EventInfo struct {
 
 func NewEventInfo(x, y int) *EventInfo {
 	info := &EventInfo{}
-	info.text = tl.NewText(x, y, "click somewhere", tl.ColorWhite, tl.ColorBlack)
+	info.text = tl.NewText(x, y, "Click somewhere", tl.ColorWhite, tl.ColorBlack)
 	return info
 }
 

--- a/_examples/click.go
+++ b/_examples/click.go
@@ -1,6 +1,46 @@
 package main
 
-import tl "github.com/JoelOtter/termloop"
+import (
+	"fmt"
+
+	tl "github.com/JoelOtter/termloop"
+)
+
+type EventInfo struct {
+	text *tl.Text
+}
+
+func NewEventInfo(x, y int) *EventInfo {
+	info := &EventInfo{}
+	info.text = tl.NewText(x, y, "click somewhere", tl.ColorWhite, tl.ColorBlack)
+	return info
+}
+
+func (info *EventInfo) Draw(screen *tl.Screen) {
+	info.text.Draw(screen)
+}
+
+func (info *EventInfo) Tick(ev tl.Event) {
+	if ev.Type != tl.EventMouse {
+		return
+	}
+	name := "Unknown Event"
+	switch ev.Key {
+	case tl.MouseLeft:
+		name = "Mouse Left"
+	case tl.MouseMiddle:
+		name = "Mouse Middle"
+	case tl.MouseRight:
+		name = "Mouse Right"
+	case tl.MouseWheelUp:
+		name = "Mouse Wheel Up"
+	case tl.MouseWheelDown:
+		name = "Mouse Wheel Down"
+	case tl.MouseRelease:
+		name = "Mouse Release"
+	}
+	info.text.SetText(fmt.Sprintf("%s @ [%d, %d]", name, ev.MouseX, ev.MouseY))
+}
 
 type Clickable struct {
 	r *tl.Rectangle
@@ -29,9 +69,9 @@ func (c *Clickable) Tick(ev tl.Event) {
 
 func main() {
 	g := tl.NewGame()
-
+	g.Screen().AddEntity(NewEventInfo(0, 0))
 	for i := 0; i < 40; i++ {
-		for j := 0; j < 20; j++ {
+		for j := 1; j < 20; j++ {
 			g.Screen().AddEntity(NewClickable(i, j, 1, 1, tl.ColorWhite))
 		}
 	}

--- a/termloop.go
+++ b/termloop.go
@@ -1,8 +1,9 @@
 package termloop
 
 import (
-	"github.com/nsf/termbox-go"
 	"strings"
+
+	"github.com/nsf/termbox-go"
 )
 
 // A Canvas is a 2D array of Cells, used for drawing.
@@ -213,6 +214,9 @@ const (
 	MouseLeft
 	MouseMiddle
 	MouseRight
+	MouseRelease
+	MouseWheelUp
+	MouseWheelDown
 )
 
 const (

--- a/termloop.go
+++ b/termloop.go
@@ -1,9 +1,8 @@
 package termloop
 
 import (
-	"strings"
-
 	"github.com/nsf/termbox-go"
+	"strings"
 )
 
 // A Canvas is a 2D array of Cells, used for drawing.


### PR DESCRIPTION
Fixes #25 

This just defines the missing mouse constants from termbox-go. There doesn't seem to be anything more needed to handle these mouse events. But let me know if I'm missing something and I will update the patch.