### PR TITLE
Fix a crash when changing running game screen.

### DIFF
--- a/game.go
+++ b/game.go
@@ -33,6 +33,7 @@ func (g *Game) Screen() *Screen {
 // SetScreen sets the current Screen of a Game.
 func (g *Game) SetScreen(s *Screen) {
 	g.screen = s
+	g.screen.resize(termbox.Size())
 }
 
 // DebugOn returns a bool showing whether or not debug mode is on.


### PR DESCRIPTION
If you call the SetScreen method after the game has already started it
will crash while trying to draw the new screen, because it wasn't
resized yet.