### PR TITLE
Solved high cpu usage in examples

### DIFF
--- a/_examples/click.go
+++ b/_examples/click.go
@@ -58,6 +58,7 @@ func (c *Clickable) Tick(ev tl.Event) {
 
 func main() {
 	g := tl.NewGame()
+	g.Screen().SetFps(60)
 	g.Screen().AddEntity(NewEventInfo(0, 0))
 	for i := 0; i < 40; i++ {
 		for j := 1; j < 20; j++ {

--- a/_examples/entityfromfile.go
+++ b/_examples/entityfromfile.go
@@ -13,6 +13,7 @@ func check(e error) {
 
 func main() {
 	g := tl.NewGame()
+	g.Screen().SetFps(60)
 	dat, err := ioutil.ReadFile("lorry.txt")
 	check(err)
 	e := tl.NewEntityFromCanvas(1, 1, tl.CanvasFromString(string(dat)))

--- a/_examples/image.go
+++ b/_examples/image.go
@@ -45,6 +45,7 @@ func main() {
 	}
 
 	g := tl.NewGame()
+	g.Screen().SetFps(30)
 	g.Screen().EnablePixelMode()
 	c := tl.BackgroundCanvasFromFile(os.Args[1])
 	g.Screen().AddEntity(NewImage(c))

--- a/_examples/levelmap.go
+++ b/_examples/levelmap.go
@@ -49,6 +49,7 @@ func checkErr(err error) {
 
 func main() {
 	g := tl.NewGame()
+	g.Screen().SetFps(30)
 	l := tl.NewBaseLevel(tl.Cell{Bg: 76, Fg: 1})
 	lmap, err := ioutil.ReadFile("level.json")
 	checkErr(err)

--- a/_examples/movingtext.go
+++ b/_examples/movingtext.go
@@ -34,6 +34,7 @@ func main() {
 		return
 	}
 	g := tl.NewGame()
+	g.Screen().SetFps(30)
 	g.Screen().AddEntity(&MovingText{tl.NewText(0, 0, os.Args[1], tl.ColorWhite, tl.ColorBlue)})
 	g.Start()
 }

--- a/_examples/pyramid.go
+++ b/_examples/pyramid.go
@@ -193,6 +193,7 @@ func buildLevel(g *tl.Game, w, h, score int) {
 
 func main() {
 	g := tl.NewGame()
+	g.Screen().SetFps(60)
 	buildLevel(g, 6, 2, 0)
 	g.SetDebugOn(true)
 	g.Start()

--- a/_examples/tutorial.go
+++ b/_examples/tutorial.go
@@ -41,6 +41,7 @@ func (player *Player) Collide(collision tl.Physical) {
 
 func main() {
 	game := tl.NewGame()
+	game.Screen().SetFps(30)
 	level := tl.NewBaseLevel(tl.Cell{
 		Bg: tl.ColorGreen,
 		Fg: tl.ColorBlack,


### PR DESCRIPTION
Signed-off-by: lucas59356 <lucas59356@gmail.com>

The examples as is have an unnecessarily expensive loop, I just added an FPS limit for each one. Now is everything using about 2% CPU, except image example, if I decrease more it gets laggy.

I really enjoyed the pyramid example :p