### PR TITLE
Add Start with context

### DIFF
--- a/game.go
+++ b/game.go
@@ -3,6 +3,7 @@ package termloop
 import (
 	"context"
 	"fmt"
+        "github.com/nsf/termbox-go"
 	"time"
 )
 

--- a/game.go
+++ b/game.go
@@ -81,8 +81,9 @@ func (g *Game) Start() {
 	g.StartCtx(context.Background())
 }
 
-// Start starts a Game running. This should be the last thing called in your
+// StartCtx starts a Game running. This should be the last thing called in your
 // main function. By default, the escape key exits.
+// Can provide a context that can be cancelled
 func (g *Game) StartCtx(ctx context.Context) {
 	// Init Termbox
 	err := termbox.Init()

--- a/game.go
+++ b/game.go
@@ -3,7 +3,7 @@ package termloop
 import (
 	"context"
 	"fmt"
-        "github.com/nsf/termbox-go"
+	"github.com/nsf/termbox-go"
 	"time"
 )
 


### PR DESCRIPTION
I would like to have control of the user interface via signalling. Preferably using context.

This PR adds a StartCtx that accepts a context that can be cancelled.

